### PR TITLE
fix(vor-14072): EXT-X-MAP-BYTERANGE should be quoted

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -449,10 +449,11 @@ func (p *MediaPlaylist) Encode() *bytes.Buffer {
 		p.buf.WriteString(p.Map.URI)
 		p.buf.WriteRune('"')
 		if p.Map.Limit > 0 {
-			p.buf.WriteString(",BYTERANGE=")
+			p.buf.WriteString(`,BYTERANGE="`)
 			p.buf.WriteString(strconv.FormatInt(p.Map.Limit, 10))
 			p.buf.WriteRune('@')
 			p.buf.WriteString(strconv.FormatInt(p.Map.Offset, 10))
+			p.buf.WriteString(`"`)
 		}
 		p.buf.WriteRune('\n')
 	}
@@ -652,10 +653,11 @@ func (p *MediaPlaylist) Encode() *bytes.Buffer {
 			p.buf.WriteString(seg.Map.URI)
 			p.buf.WriteRune('"')
 			if seg.Map.Limit > 0 {
-				p.buf.WriteString(",BYTERANGE=")
+				p.buf.WriteString(`,BYTERANGE="`)
 				p.buf.WriteString(strconv.FormatInt(seg.Map.Limit, 10))
 				p.buf.WriteRune('@')
 				p.buf.WriteString(strconv.FormatInt(seg.Map.Offset, 10))
+				p.buf.WriteString(`"`)
 			}
 			p.buf.WriteRune('\n')
 		}

--- a/writer_test.go
+++ b/writer_test.go
@@ -315,7 +315,7 @@ func TestSetDefaultMapForMediaPlaylist(t *testing.T) {
 	}
 	p.SetDefaultMap("https://example.com", 1000*1024, 1024*1024)
 
-	expected := `EXT-X-MAP:URI="https://example.com",BYTERANGE=1024000@1048576`
+	expected := `EXT-X-MAP:URI="https://example.com",BYTERANGE="1024000@1048576"`
 	if !strings.Contains(p.String(), expected) {
 		t.Fatalf("Media playlist did not contain: %s\nMedia Playlist:\n%v", expected, p.String())
 	}
@@ -338,7 +338,7 @@ func TestSetMapForMediaPlaylist(t *testing.T) {
 		t.Errorf("Set map to a media playlist failed: %s", e)
 	}
 
-	expected := `EXT-X-MAP:URI="https://example.com",BYTERANGE=1024000@1048576
+	expected := `EXT-X-MAP:URI="https://example.com",BYTERANGE="1024000@1048576"
 #EXTINF:5.000,
 test01.ts`
 	if !strings.Contains(p.String(), expected) {
@@ -367,7 +367,7 @@ func TestEncodeMediaPlaylistWithDefaultMap(t *testing.T) {
 	}
 
 	encoded := p.String()
-	expected := `EXT-X-MAP:URI="https://example.com",BYTERANGE=1024000@1048576`
+	expected := `EXT-X-MAP:URI="https://example.com",BYTERANGE="1024000@1048576"`
 	if !strings.Contains(encoded, expected) {
 		t.Fatalf("Media playlist did not contain: %s\nMedia Playlist:\n%v", expected, encoded)
 	}


### PR DESCRIPTION
https://vivotek.atlassian.net/browse/VOR-14072

ref: https://github.com/grafov/m3u8/pull/159